### PR TITLE
:recycle: replace componentWillMount by componentDidMount

### DIFF
--- a/components/react/k-ramel/src/hoc.jsx
+++ b/components/react/k-ramel/src/hoc.jsx
@@ -21,7 +21,7 @@ const hoc = (code, options) => Component => class extends React.Component {
     this.state = { show: false }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { store } = this.context
 
     // subscribe

--- a/components/react/redux/src/hoc.jsx
+++ b/components/react/redux/src/hoc.jsx
@@ -34,7 +34,7 @@ const hoc = (code, options = {}) => (Component) => {
       this.state = { show: false }
     }
 
-    componentWillMount() {
+    componentDidMount() {
       const { store } = this.context
       // subscribe
       this.unsubscribe = store.subscribe(() => {


### PR DESCRIPTION
With new version of react `componentWillMount` is deprecated, and will be removed in the next major version. So I changed it by the `componentDidMount` which seems correct because component will be mounted but not displayed by default (with state `show=false`), then once mounted it will the correct test.

It avoids lot of annoying messages in the console in dev mode. Here in the conference hall project:
![image](https://user-images.githubusercontent.com/516360/69479538-a6d43200-0dfe-11ea-9eac-5a72098be2ad.png)

If you dont agree to replace it by `componentDidMount`, we can simply replace it by `UNSAFE_componentWillMount`. But it wont be future proof.